### PR TITLE
Add button to download samples

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,8 @@
       "@/*": ["./*"],
       "~~/*": ["./*"],
       "@@/*": ["./*"]
-    }
+    },
+    "extensions": [".vue"]
   },
   "exclude": ["node_modules", ".nuxt", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "core-js": "^3.25.3",
+    "file-saver": "^2.0.5",
     "lodash.throttle": "^4.1.1",
     "nuxt": "^2.15.8",
     "vue": "^2.7.10",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,6 +13,7 @@
       <div class="sample-count">
         total samples: {{ singles.length + sets.length }}
       </div>
+      <button @click="logSamples">download samples</button>
 
       <SampleBook
         :singles="selectedSingles"
@@ -29,6 +30,7 @@
 </template>
 
 <script>
+import { saveAs } from 'file-saver'
 export default {
   name: 'IndexPage',
   data: () => {
@@ -78,6 +80,13 @@ export default {
         caption: this.$store.state.sampleMaker.caption,
       })
       this.$store.commit('sampleMaker/clear')
+    },
+    logSamples() {
+      const samples = {
+        singles: this.$store.state.samples.singles,
+        sets: this.$store.state.samples.sets,
+      }
+      saveAs(new Blob([JSON.stringify(samples)]), 'samples.json')
     },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,6 +4025,11 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"


### PR DESCRIPTION
Closes #12 

Adds a button on the sample maker page that will download a .json file called 'samples.json'
We can replace the samples.json in the repo with this new file to incorporate new sets into the data