### PR TITLE
Add dynamic pages to view individual sets

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -36,6 +36,21 @@ body {
   font-family: var(--font-family);
 }
 
+/* 
+all items in the /pages directory should have a <main> tag that wraps all content
+this style will apply to all of them, and properly sets up the the page content underneath the top navigation bar
+*/
+main {
+  margin-top: var(--topbar-height);
+  position: absolute;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 2em;
+  gap: 2em;
+}
+
 button {
   cursor: pointer;
   background: none;

--- a/components/Sample.vue
+++ b/components/Sample.vue
@@ -10,6 +10,7 @@
     </div>
 
     <div class="info">
+      <NuxtLink v-if="set" :to="'/sets/' + set.id"> view set </NuxtLink>
       <div class="title">{{ caption }}</div>
       <div v-if="selectable" class="parents">
         <span v-for="parent in parents" :key="parent.id" class="parent">

--- a/components/TopBar.vue
+++ b/components/TopBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <main>
+  <div class="topbar-wrapper">
     <div class="left">
       <NuxtLink to="/"> Sampler </NuxtLink>
     </div>
@@ -9,11 +9,11 @@
       <NuxtLink to="/sampleStack"> Sample Stack </NuxtLink>
       <NuxtLink to="/sampleGenerator"> Sample Generator </NuxtLink>
     </div>
-  </main>
+  </div>
 </template>
 
 <style scoped>
-main {
+.topbar-wrapper {
   z-index: 1;
   position: fixed;
   width: 100%;

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -11,15 +11,4 @@ export default {
 }
 </script>
 
-<style scoped>
-main {
-  margin-top: var(--topbar-height);
-  position: absolute;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  padding: 2em;
-  gap: 2em;
-}
-</style>
+<style scoped></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,15 +11,4 @@ export default {
 }
 </script>
 
-<style scoped>
-main {
-  margin-top: var(--topbar-height);
-  position: absolute;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  padding: 2em;
-  gap: 2em;
-}
-</style>
+<style scoped></style>

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -11,15 +11,4 @@ export default {
 }
 </script>
 
-<style scoped>
-main {
-  margin-top: var(--topbar-height);
-  position: absolute;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  padding: 2em;
-  gap: 2em;
-}
-</style>
+<style scoped></style>

--- a/pages/sampleGenerator.vue
+++ b/pages/sampleGenerator.vue
@@ -93,19 +93,6 @@ export default {
 </script>
 
 <style scoped>
-main {
-  margin-top: var(--topbar-height);
-  position: absolute;
-  width: 100%;
-  height: calc(100% - var(--topbar-height));
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  padding: 2em;
-  gap: 2em;
-  background: var(--background-gradient);
-}
-
 .sidebar {
   flex-shrink: 0;
   display: flex;

--- a/pages/sampleStack.vue
+++ b/pages/sampleStack.vue
@@ -11,15 +11,4 @@ export default {
 }
 </script>
 
-<style scoped>
-main {
-  margin-top: var(--topbar-height);
-  position: absolute;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  padding: 2em;
-  gap: 2em;
-}
-</style>
+<style scoped></style>

--- a/pages/sets/_setId.vue
+++ b/pages/sets/_setId.vue
@@ -1,0 +1,23 @@
+<!-- 
+this is a dynamicly generated page to display a single set based on the URL route
+that lives at /sets/{{setId}} (this structure is based on the directory structure of this pages/ folder)
+it can be called from any component with the following:
+<NuxtLink v-if="set" :to="'/sets/'+set.id"> view set </NuxtLink>
+this page will then access the set from our store using the passed in setID, and programatically display the set or project
+ -->
+
+<template>
+  <main>this is a page for individual set #{{ setId }}</main>
+</template>
+
+<script>
+export default {
+  computed: {
+    setId() {
+      return this.$route.params.setId
+    },
+  },
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Closes #18.

This PR adds functionality to view a single set or project within its own unique route. 

Nuxt makes this pretty easy:
- within `pages/` I added the folder `sets/`, and within that, a dynamically generated page view (signified with an underscore before the name) called `_setId.vue`
- this makes it so that when a user navigates to `.../sets/003` our dynamically generated page will load, and we can easily access that setId parameter, retrieve all the set information from our store, and then dynamically render the appropriate images and content
- right now im simply writing out the setId number while we are ironing out our data structure and types of information we'll want, but this takes care of all the routing stuff, everything else will be html/css
- I've also added a test link to the `Sample.vue` component which navigates to this dynamic page from all sets that exist in the sampleGenerator view. It's pretty easy to do and seems to work well!

I'm happy to reconsider naming for a lot of these directories and pages. I know we're still figuring out exactly how sets and projects are conceptually related - it may be that we want to have dynamic pages for both sets and projects in future - but that will be a very simple extension of the concepts and structure introduced here, so should be very straightforward technically.